### PR TITLE
Correct broadcasting: Use channelName instead of channel

### DIFF
--- a/angular-pusher.js
+++ b/angular-pusher.js
@@ -90,7 +90,7 @@ angular.module('doowb.angular-pusher', [])
                     var channel = pusher.channel(channelName) || pusher.subscribe(channelName);
 					channel.bind(eventName, function (data) {
 						if (callback) callback(data);
-						$rootScope.$broadcast(channel + ':' + eventName, data);
+						$rootScope.$broadcast(channelName + ':' + eventName, data);
 						$rootScope.$digest();
 					});
 				});


### PR DESCRIPTION
Channel is an object, which will cause the broadcast event name to be '[Object object]:event_name'
