### PR TITLE
Returning a channel from Pusher.subscribe

### DIFF
--- a/angular-pusher.js
+++ b/angular-pusher.js
@@ -84,7 +84,7 @@ angular.module('doowb.angular-pusher', [])
 
 .factory('Pusher', ['$rootScope', 'PusherService',
   function ($rootScope, PusherService) {
-    return {
+    var factory = {
 
       subscribe: function (channelName, eventName, callback) {
         PusherService.then(function (pusher) {
@@ -103,5 +103,7 @@ angular.module('doowb.angular-pusher', [])
         });
       }
     };
+    
+    return factory;
   }
 ]);


### PR DESCRIPTION
Hey! On the [client-event#trigger-events](http://pusher.com/docs/client_api_guide/client_events#trigger-events) section of the
docs, triggering client events is suggested to look like

``` javascript
var pusher = new Pusher('YOUR_APP_KEY');
var channel = pusher.subscribe('private-channel');
channel.bind('pusher:subscription_succeeded', function() {
  var triggered = channel.trigger('client-someeventname', { your: data });
});
```

But, this doesn't work in this angular-pusher library, because this
lib's `Pusher.subscribe` [doesn't return anything](https://github.com/doowb/angular-pusher/blob/gh-pages/angular-pusher.js#L89-L98). How do you
want to get the channels back out of this library's Pusher.subscribe
method? It's all taking place in a promise, so it seemed a bit
complicated to me to get just a channel object out. 

As a kludge, I put the currently subscribed channel
[on the Pusher factory itself](https://github.com/gempesaw/honeydew-ng/blob/master/app/bower_components/angular-pusher/angular-pusher.js#L92), but that doesn't generalize to
multiple channels, and the interface is different from the normal JS
library. I couldn't figure out a way to mirror the normal interface
because of the promise, so I'm curious if y'all have already thought
about this.
