### PR TITLE
Pusher.subscribe returns a promise for the channel

### DIFF
--- a/angular-pusher.js
+++ b/angular-pusher.js
@@ -81,19 +81,22 @@ angular.module('doowb.angular-pusher', [])
 
 })
 
-.factory('Pusher', ['$rootScope', 'PusherService',
-  function ($rootScope, PusherService) {
+.factory('Pusher', ['$rootScope', '$q', 'PusherService',
+  function ($rootScope, $q, PusherService) {
     return {
 
       subscribe: function (channelName, eventName, callback) {
+        var channelDeferred = $q.defer()
         PusherService.then(function (pusher) {
           var channel = pusher.channel(channelName) || pusher.subscribe(channelName);
+          channelDeferred.resolve(channel)
           channel.bind(eventName, function (data) {
             if (callback) callback(data);
             $rootScope.$broadcast(channelName + ':' + eventName, data);
             $rootScope.$digest();
           });
         });
+        return channelDeferred.promise
       },
 
       unsubscribe: function (channelName) {


### PR DESCRIPTION
In the current implementation it is difficult to use some Pusher API features as subscribing does not return a reference to the channel. 

Since Pusher.subscribe is async in this codebase, I added a dependency on $q and changed subscribe to return a promise that gets filled with the channel when it is subscribed.  This allows using functionality like channel.members on a presence channel.

In theory this would also allow for dropping eventName and callback from the subscribe method signature; consuming clients could write their own bindings as in the standard pusher-js library. I left as is for now, since this would constitute a breaking change.
